### PR TITLE
wip: Demonstrate conformance test

### DIFF
--- a/e2e/setup/setup.go
+++ b/e2e/setup/setup.go
@@ -3,6 +3,8 @@ package setup
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/cosmos/ibc-go/v3/e2e/testconfig"
 	"github.com/strangelove-ventures/ibctest"
 	"github.com/strangelove-ventures/ibctest/chain/cosmos"
@@ -10,7 +12,6 @@ import (
 	"github.com/strangelove-ventures/ibctest/testreporter"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
-	"testing"
 )
 
 // StandardTwoChainEnvironment creates two default simapp containers as well as a go relayer container.
@@ -72,16 +73,16 @@ type Options struct {
 }
 
 func defaultSetupOpts() *Options {
-	chainAConfig := newSimappConfig("simapp-a", "chain-a", "atoma")
-	chainBConfig := newSimappConfig("simapp-b", "chain-b", "atomb")
+	chainAConfig := NewSimappConfig("simapp-a", "chain-a", "atoma")
+	chainBConfig := NewSimappConfig("simapp-b", "chain-b", "atomb")
 	return &Options{
 		ChainAConfig: &chainAConfig,
 		ChainBConfig: &chainBConfig,
 	}
 }
 
-// newSimappConfig creates an ibc configuration for simd.
-func newSimappConfig(name, chainId, denom string) ibc.ChainConfig {
+// NewSimappConfig creates an ibc configuration for simd.
+func NewSimappConfig(name, chainId, denom string) ibc.ChainConfig {
 	tc := testconfig.FromEnv()
 	return ibc.ChainConfig{
 		Type:    "cosmos",

--- a/e2e/token_transfer_test.go
+++ b/e2e/token_transfer_test.go
@@ -3,23 +3,40 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/cosmos/ibc-go/v3/e2e/setup"
 	"github.com/cosmos/ibc-go/v3/e2e/testconfig"
 	transfertypes "github.com/cosmos/ibc-go/v3/modules/apps/transfer/types"
 	"github.com/strangelove-ventures/ibctest"
+	"github.com/strangelove-ventures/ibctest/conformance"
 	"github.com/strangelove-ventures/ibctest/ibc"
 	"github.com/strangelove-ventures/ibctest/test"
 	"github.com/strangelove-ventures/ibctest/testreporter"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
 	"golang.org/x/sync/errgroup"
-	"strings"
-	"testing"
-	"time"
 )
 
 const (
 	pollHeightMax = uint64(50)
 )
+
+func TestConformance(t *testing.T) {
+	os.Setenv("SIMD_TAG", "v3.0.0") // TODO - Remove this line!!!
+
+	logger := zaptest.NewLogger(t)
+	cf := ibctest.NewBuiltinChainFactory(logger, []*ibctest.ChainSpec{
+		{Name: "gaia", ChainConfig: setup.NewSimappConfig("simapp-a", "chain-a", "atoma")},
+		{Name: "gaia", ChainConfig: setup.NewSimappConfig("simapp-b", "chain-b", "atomb")},
+	})
+	rf := ibctest.NewBuiltinRelayerFactory(ibc.CosmosRly, logger)
+
+	conformance.TestChainPair(t, cf, rf, testreporter.NewNopReporter())
+}
 
 func TestTokenTransfer(t *testing.T) {
 	ctx := context.TODO()


### PR DESCRIPTION
Demonstrates how to setup a simple conformace test. 

I did not use `conformance.Test` because I assume we're not interested in the relayer side of tests (i.e. relayer can flush and set itself up.) We're only interested in the chain interaction. 

The tests pass!

Thoughts:
* The configuration is confusing. We'll work to improve that. The reason I have to specify `gaia` is that the factory pulls in default config then overrides it with the config you want. 
* `conformance.TestChainPair` tests IBC transfer bidirectionally chainA <-> chainB. It also tests timeout behavior (height, timestamp, no timeout). This method may need a better name or better godoc. 